### PR TITLE
Add module description

### DIFF
--- a/bansearch.py
+++ b/bansearch.py
@@ -10,6 +10,7 @@ from datetime import datetime
 class bansearch(znc.Module):
 
     module_types = [znc.CModInfo.NetworkModule]
+    description = "Ban/Quiet searching module"
 
     def OnLoad(self, args, message):
         self.loadSettings()


### PR DESCRIPTION
The module does not include a description so we get a placeholder in the ```msg *status listmods```, ```msg *status listavailmods```, and the ```webadmin``` module.

Current response:
```<*status>  bansearch: < Placeholder for a description >```

This pull request adds a description: 
```<*status>  bansearch: Ban/Quiet searching module```